### PR TITLE
[STYLE] 통계 API에서 조회 날짜 관련 Query string과 Path variable 중복 해결

### DIFF
--- a/src/main/java/com/doittogether/platform/presentation/controller/stastics/StatisticsController.java
+++ b/src/main/java/com/doittogether/platform/presentation/controller/stastics/StatisticsController.java
@@ -20,7 +20,7 @@ import java.time.LocalDate;
 @RequestMapping("/api/v1/channels/{channelId}/statistics")
 public interface StatisticsController {
 
-    @GetMapping("/weekly/{targetDate}/totalCount")
+    @GetMapping("/weekly/totalCount")
     @Operation(summary = "주간 통계관련 완료 미완료 칭찬 찌르기 개수 조회", description = "주간 통계에서 사용할, 이번주 완료 개수 랭킹을 반환합니다.")
     ResponseEntity<SuccessResponse<ChannelCountStatisticsResponse>> calculateTotalCountByChannelId(
             Principal principal,
@@ -30,7 +30,7 @@ public interface StatisticsController {
             @Parameter(description = "선택 날짜 (yyyy-MM-dd 형식)", example = "2024-11-25") LocalDate targetDate
     );
 
-    @GetMapping("/weekly/{targetDate}/score")
+    @GetMapping("/weekly/score")
     @Operation(summary = "주간 통계, 이번주 완료 개수 랭킹", description = "주간통계 중, 이번주 완료 개수 랭킹을 반환합니다.")
     ResponseEntity<SuccessResponse<CompleteScoreResponse>> calculateWeeklyStatistics(
             Principal principal,
@@ -41,7 +41,7 @@ public interface StatisticsController {
     );
 
 
-    @GetMapping("/monthly/{targetMonth}/score")
+    @GetMapping("/monthly/score")
     @Operation(summary = "월간 통계, 캘린더 부분 조회", description = "월간통계 중, 캘린더 부분에 사용될 데이터를 반환합니다.")
     ResponseEntity<SuccessResponse<MonthlyStatisticsResponse>> calculateMonthlyStatistics(
             Principal principal,
@@ -50,7 +50,7 @@ public interface StatisticsController {
             @Parameter(description = "선택 월 (yyyy-MM 형식)", example = "2024-11") String targetDate
     );
 
-    @GetMapping("/monthly/{targetMonth}/score")
+    @GetMapping("/monthly/score")
     @Operation(summary = "월간 통계,MVP 부분 조회", description = "월간통계 중, MVP 부분에 사용될 데이터를 반환합니다.")
     ResponseEntity<SuccessResponse<MonthlyMVPResponse>> calculateMonthlyMVP(
             Principal principal,

--- a/src/main/java/com/doittogether/platform/presentation/controller/stastics/StatisticsControllerImpl.java
+++ b/src/main/java/com/doittogether/platform/presentation/controller/stastics/StatisticsControllerImpl.java
@@ -30,7 +30,7 @@ public class StatisticsControllerImpl implements StatisticsController {
     private final StatisticsService statisticsService;
     private final UserService userService;
 
-    @GetMapping("/weekly/{targetDate}/totalCount")
+    @GetMapping("/weekly/totalCount")
     @Operation(summary = "주간 통계관련 완료 미완료 칭찬 찌르기 개수 조회", description = "주간 통계에서 사용할, 이번주 완료 개수 랭킹을 반환합니다.")
     @Override
     public ResponseEntity<SuccessResponse<ChannelCountStatisticsResponse>> calculateTotalCountByChannelId(
@@ -49,7 +49,7 @@ public class StatisticsControllerImpl implements StatisticsController {
                 ));
     }
 
-    @GetMapping("/weekly/{targetDate}/score")
+    @GetMapping("/weekly/score")
     @Operation(summary = "주간 통계, 이번주 완료 개수 랭킹", description = "주간통계 중, 이번주 완료 개수 랭킹을 반환합니다.")
     @Override
     public ResponseEntity<SuccessResponse<CompleteScoreResponse>> calculateWeeklyStatistics(
@@ -68,7 +68,7 @@ public class StatisticsControllerImpl implements StatisticsController {
                 ));
     }
 
-    @GetMapping("/monthly/{targetMonth}/score")
+    @GetMapping("/monthly/score")
     @Operation(summary = "월간 통계, 캘린더 부분 조회", description = "월간통계 중, 캘린더 부분에 사용될 데이터를 반환합니다.")
     @Override
     public ResponseEntity<SuccessResponse<MonthlyStatisticsResponse>> calculateMonthlyStatistics(
@@ -87,7 +87,7 @@ public class StatisticsControllerImpl implements StatisticsController {
                 ));
     }
 
-    @GetMapping("/monthly/{targetMonth}/mvp")
+    @GetMapping("/monthly/mvp")
     @Operation(summary = "월간 통계,MVP 부분 조회", description = "월간통계 중, MVP 부분에 사용될 데이터를 반환합니다.")
     @Override
     public ResponseEntity<SuccessResponse<MonthlyMVPResponse>> calculateMonthlyMVP(


### PR DESCRIPTION
…le 제거

<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

> #### 🔗 관련 이슈
> 
> <!-- 관련 이슈가 어떤건지 작성해주세요 -->
> 
> close

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
통계 API에서 조회 시 날짜 입력 방법에서 Query string과 Path variable 두 방법이 중복으로 적용되어 있어 Path variable를 제거하였습니다.
## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->

## 💻 실행 결과 <!-- 쿼리 동작 캡쳐 화면과 테스트 코드 통과 캡쳐 화면을 넣어주세요 -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
