### PR TITLE
[FEAT] 집안일 일간 별 미완료 개수 조회(조회 범위 : 일주일, 일~토) 기능 추가

### DIFF
--- a/src/main/java/com/doittogether/platform/business/housework/HouseworkService.java
+++ b/src/main/java/com/doittogether/platform/business/housework/HouseworkService.java
@@ -4,34 +4,34 @@ import com.doittogether.platform.domain.entity.User;
 import com.doittogether.platform.presentation.dto.housework.HouseworkRequest;
 import com.doittogether.platform.presentation.dto.housework.HouseworkResponse;
 import com.doittogether.platform.presentation.dto.housework.HouseworkSliceResponse;
-import jakarta.validation.Valid;
-import java.time.LocalDate;
-import java.util.Map;
-
+import com.doittogether.platform.presentation.dto.housework.IncompleteScoreResponse;
 import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDate;
+import java.util.Map;
 
 public interface HouseworkService {
-    public HouseworkSliceResponse findAllByChannelIdAndTargetDate(final User loginUser, final Long channelId,
-                                                                  final LocalDate targetDate, final Pageable pageable);
+    HouseworkSliceResponse findAllByChannelIdAndTargetDate(final User loginUser, final Long channelId,
+                                                           final LocalDate targetDate, final Pageable pageable);
 
-    public HouseworkSliceResponse findAllByChannelIdAndTargetDateAndAssigneeId(final User loginUser,
-                                                                               final Long channelId,
-                                                                               final LocalDate targetDate,
-                                                                               final Long assigneeId,
-                                                                               final Pageable pageable);
+    HouseworkSliceResponse findAllByChannelIdAndTargetDateAndAssigneeId(final User loginUser,
+                                                                        final Long channelId,
+                                                                        final LocalDate targetDate,
+                                                                        final Long assigneeId,
+                                                                        final Pageable pageable);
 
-    public void addHousework(final User loginUser, final Long channelId, final HouseworkRequest request);
+    void addHousework(final User loginUser, final Long channelId, final HouseworkRequest request);
 
-    public void updateHousework(final User loginUser, final Long houseworkId, final Long channelId,
+    void updateHousework(final User loginUser, final Long houseworkId, final Long channelId,
                                 final HouseworkRequest request);
 
-    public void deleteHousework(final User loginUser, final Long houseworkId, final Long channelId);
+    void deleteHousework(final User loginUser, final Long houseworkId, final Long channelId);
 
-    public HouseworkResponse findHouseworkByChannelIdAndHouseworkId(final User user, final Long houseworkId, final Long channelId);
+    HouseworkResponse findHouseworkByChannelIdAndHouseworkId(final User user, final Long houseworkId, final Long channelId);
 
-    public void updateStatus(User loginUser, Long houseworkId, Long channelId);
+    void updateStatus(User loginUser, Long houseworkId, Long channelId);
 
-    public Map<String, Integer> calculateHouseworkStatisticsForWeek(Long channelId, LocalDate targetDate);
+    Map<String, Integer> calculateHouseworkStatisticsForWeek(Long channelId, LocalDate targetDate);
+
+    IncompleteScoreResponse incompleteScoreResponse(User loginuser, Long channelId, LocalDate targetDate);
 }

--- a/src/main/java/com/doittogether/platform/presentation/controller/housework/HouseworkController.java
+++ b/src/main/java/com/doittogether/platform/presentation/controller/housework/HouseworkController.java
@@ -2,10 +2,10 @@ package com.doittogether.platform.presentation.controller.housework;
 
 import com.doittogether.platform.application.global.response.ExceptionResponse;
 import com.doittogether.platform.application.global.response.SuccessResponse;
-import com.doittogether.platform.domain.entity.User;
 import com.doittogether.platform.presentation.dto.housework.HouseworkRequest;
 import com.doittogether.platform.presentation.dto.housework.HouseworkResponse;
 import com.doittogether.platform.presentation.dto.housework.HouseworkSliceResponse;
+import com.doittogether.platform.presentation.dto.housework.IncompleteScoreResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -13,19 +13,12 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
-import java.security.Principal;
-import java.time.LocalDate;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.*;
+
+import java.security.Principal;
+import java.time.LocalDate;
 
 @RequestMapping("/api/v1/channels/{channelId}/houseworks")
 public interface HouseworkController {
@@ -128,4 +121,13 @@ public interface HouseworkController {
     ResponseEntity<SuccessResponse<Void>> deleteHousework(Principal principal,
                                                           @PathVariable("channelId") Long channelId,
                                                           @PathVariable(name = "houseworkId") Long houseworkId);
+
+    @GetMapping("/daily/incomplete")
+    @Operation(summary = "집안일 일간 미 완료 개수 조회", description = "집안일 일간 별로 미 완료 개수를 조회합니다.")
+    ResponseEntity<SuccessResponse<IncompleteScoreResponse>>houseworkCalculateTotalCountByChannelId(
+            Principal principal,
+            @PathVariable("channelId") Long channelId,
+            @RequestParam("targetDate")
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+            @Parameter(description = "선택 날짜 (yyyy-MM-dd 형식)", example = "2024-11-25") LocalDate targetDate);
 }

--- a/src/main/java/com/doittogether/platform/presentation/controller/housework/HouseworkControllerImpl.java
+++ b/src/main/java/com/doittogether/platform/presentation/controller/housework/HouseworkControllerImpl.java
@@ -9,6 +9,7 @@ import com.doittogether.platform.domain.entity.User;
 import com.doittogether.platform.presentation.dto.housework.HouseworkRequest;
 import com.doittogether.platform.presentation.dto.housework.HouseworkResponse;
 import com.doittogether.platform.presentation.dto.housework.HouseworkSliceResponse;
+import com.doittogether.platform.presentation.dto.housework.IncompleteScoreResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -194,5 +195,24 @@ public class HouseworkControllerImpl implements
         houseworkService.deleteHousework(loginUser, houseworkId, channelId);
         return ResponseEntity.status(HttpStatus.OK)
                 .body(SuccessResponse.onSuccess(SuccessCode._NO_CONTENT));
+    }
+
+    @GetMapping("/daily/incomplete")
+    @Operation(summary = "집안일 일간 미 완료 개수 조회", description = "집안일 일간 별로 미 완료 개수를 조회합니다.")
+    @Override
+    public ResponseEntity<SuccessResponse<IncompleteScoreResponse>>houseworkCalculateTotalCountByChannelId(
+            Principal principal,
+            @PathVariable("channelId") Long channelId,
+            @RequestParam("targetDate")
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+            @Parameter(description = "선택 날짜 (yyyy-MM-dd 형식)", example = "2024-11-25") LocalDate targetDate
+    ){
+        Long userId = Long.parseLong(principal.getName());
+        User loginUser = userService.findByIdOrThrow(userId);
+        return ResponseEntity.status(HttpStatus.OK).body(
+                SuccessResponse.onSuccess(
+                        SuccessCode._OK,
+                        houseworkService.incompleteScoreResponse(loginUser, channelId, targetDate)
+                ));
     }
 }

--- a/src/main/java/com/doittogether/platform/presentation/dto/housework/IncompleteScoreResponse.java
+++ b/src/main/java/com/doittogether/platform/presentation/dto/housework/IncompleteScoreResponse.java
@@ -1,0 +1,16 @@
+package com.doittogether.platform.presentation.dto.housework;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record IncompleteScoreResponse (
+        List<PersonalIncompleteScoreResponse> incompleteScoreResponses
+){
+    public static IncompleteScoreResponse of (List<PersonalIncompleteScoreResponse> dailyHousework){
+        return IncompleteScoreResponse.builder()
+                .incompleteScoreResponses(dailyHousework)
+                .build();
+    }
+}

--- a/src/main/java/com/doittogether/platform/presentation/dto/housework/PersonalIncompleteScoreResponse.java
+++ b/src/main/java/com/doittogether/platform/presentation/dto/housework/PersonalIncompleteScoreResponse.java
@@ -1,0 +1,25 @@
+package com.doittogether.platform.presentation.dto.housework;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
+
+public record PersonalIncompleteScoreResponse (
+
+        @NotNull
+        @Schema(description = "일간 날짜", example = "2024-12-05")
+        LocalDate date,
+
+        @NotNull
+        @Schema(description = "집안일 미 완료 개수", example = "10")
+        Integer houseworkIncompleteCount,
+
+        @NotNull
+        @Schema(description = "모든 집안일 해결 여부", example = "true")
+        boolean solvedMatters
+){
+    public LocalDate retrieveDate(){
+        return date;
+    }
+}


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

> #### 🔗 관련 이슈
> 
> <!-- 관련 이슈가 어떤건지 작성해주세요 -->
> 
> close

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
집안일 api에서 일간 별 미 완료 개수 조회 기능 추가하였습니다.
조회 범위는 일주일이며, 일~토까지 입니다.
## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->

## 💻 실행 결과 <!-- 쿼리 동작 캡쳐 화면과 테스트 코드 통과 캡쳐 화면을 넣어주세요 -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
